### PR TITLE
Remove start and update function

### DIFF
--- a/Assets/Scripts/IsStatic.cs
+++ b/Assets/Scripts/IsStatic.cs
@@ -5,13 +5,4 @@ using UnityEngine;
 public class IsStatic : MonoBehaviour {
 	[Header("Tick this box for a static map:")]
 	public bool staticMap;
-	// Use this for initialization
-	void Start () {
-		
-	}
-	
-	// Update is called once per frame
-	void Update () {
-		
-	}
 }


### PR DESCRIPTION
Keeping them is bad practise. Leaving them in makes it so that they will get called. This makes a difference on low end devices like my laptop